### PR TITLE
Add conclusion and future outlook section to eco-friendly design page

### DIFF
--- a/index.html/eco-friendly-design.html
+++ b/index.html/eco-friendly-design.html
@@ -266,6 +266,49 @@
             line-height: 1.8;
         }
 
+        .conclusion-box {
+            margin-top: 30px;
+            background-color: white;
+            padding: 30px;
+            border-radius: 15px;
+            border: 2px solid var(--green-2);
+            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.05);
+        }
+
+        .conclusion-box h2 {
+            font-size: 1.8rem;
+            margin-bottom: 20px;
+            color: var(--green-1);
+        }
+
+        .conclusion-box p {
+            font-size: 1.2rem;
+            font-weight: 600;
+            margin-bottom: 20px;
+            color: var(--earth-2);
+        }
+
+        .conclusion-box ul {
+            list-style: none;
+            margin-left: 10px;
+        }
+
+        .conclusion-box li {
+            margin-bottom: 12px;
+            padding-left: 25px;
+            position: relative;
+        }
+
+        .conclusion-box li::before {
+            content: "•";
+            position: absolute;
+            left: 0;
+            top: 0;
+            color: var(--green-2);
+            font-size: 1.2rem;
+            font-weight: bold;
+        }
+
         .leaf-divider {
             text-align: center;
             margin: 40px 0;
@@ -498,6 +541,18 @@
                 <p>南インド発シーフード輸入事業は、単なる商品取引を超え、持続可能性、透明性、そして文化的価値を統合した総合的なエコシステム構築として位置づけることで差別化が可能です。SMARTゴールの枠組みに水平思考を組み合わせることで、業界の常識にとらわれない創造的なアプローチが生まれ、環境・社会・経済の三側面でポジティブインパクトを生み出せます。</p>
                 <p>特に重要なのは、デジタル技術とストーリーテリングを活用した透明性の確保、小規模生産者との直接的な関係構築、そして「食材」を超えた「文化・体験」としての価値提案です。これらによって、価格競争に陥りがちな輸入食品市場において、独自のポジションを確立し、持続的な事業成長と社会的価値創出の両立が期待できます。</p>
             </div>
+        </section>
+
+        <section class="conclusion-box">
+            <h2>結論</h2>
+            <p>Codexは単なる開発支援ツールではない。<br>「仕事を代替するAI」への進化段階に突入した。</p>
+
+            <h2>今後の展望</h2>
+            <ul>
+                <li>完全自律エージェント化</li>
+                <li>AI主導の組織運営</li>
+                <li>人間の役割は意思決定へシフト</li>
+            </ul>
         </section>
     </main>
 


### PR DESCRIPTION
### Motivation
- Add a highlighted final section to present a clear conclusion and future outlook on the project page and ensure it visually matches the existing design.

### Description
- Added a `.conclusion-box` CSS block with styles for headings, paragraphs, and custom list markers in `index.html/eco-friendly-design.html`.
- Inserted a new `<section class="conclusion-box">` immediately after the existing summary containing a "結論" paragraph and a "今後の展望" list with three bullet points.
- Changes are content and styling only and are limited to `index.html/eco-friendly-design.html`.

### Testing
- Verified the file diff with `git diff -- index.html/eco-friendly-design.html` and confirmed the new CSS and section are present (succeeded).
- Confirmed the repository working tree status with `git status --short` and observed no outstanding changes other than the intended file update (succeeded).
- Generated PR metadata with the internal `make_pr` tool to produce the PR title and body (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50b5d5398833187939e41bb8e4dfa)